### PR TITLE
Removed --sslv3 due to poodle vulnerability

### DIFF
--- a/unifi-api.sh
+++ b/unifi-api.sh
@@ -7,7 +7,7 @@ baseurl=https://CONTROLLERURL:8443
 
 cookie=/tmp/unifi_cookie
 
-curl_cmd="curl --sslv3 --silent --cookie ${cookie} --cookie-jar ${cookie} --insecure "
+curl_cmd="curl --silent --cookie ${cookie} --cookie-jar ${cookie} --insecure "
 
 unifi_requires() {
     if [ -z "$username" -o -z "$password" -o -z "$baseurl" ] ; then


### PR DESCRIPTION
SSLV3 has been disabled by default on majors servers. Unify server doesn't support anymore sslv3.
