### PR TITLE
Update unifi-api.sh

### DIFF
--- a/unifi-api.sh
+++ b/unifi-api.sh
@@ -7,7 +7,7 @@
 
 [ -f ./unifi_sh_env ] && . ./unifi_sh_env
 
-cookie=/tmp/unifi_cookie
+cookie=unifi_cookie_tmp
 
 curl_cmd="curl --tlsv1 --silent --cookie ${cookie} --cookie-jar ${cookie} --insecure "
 
@@ -44,6 +44,7 @@ unifi_login() {
 unifi_logout() {
     # logout
     ${curl_cmd} $baseurl/logout
+    rm $cookie
 }
 
 unifi_api() {


### PR DESCRIPTION
**Change:** 
cokkie from: _/tmp/unifi_cookie_ to: _unifi_cookie_tmp_
Because not all user allowed to save in /tmp folder.

**Added:**
_rm $cookie_ in _unifi_logout_, for clear cookie every logout.